### PR TITLE
fixed bug with fsExtra.copySync

### DIFF
--- a/src/fs-helper.ts
+++ b/src/fs-helper.ts
@@ -109,7 +109,7 @@ export function stageActionFiles(actionDir: string, targetDir: string) {
       }
 
       // Filter out hidden folers like .git and .github
-      return !basename.startsWith('.')
+      return basename === '.' || !basename.startsWith('.')
     }
   })
 


### PR DESCRIPTION
fsExtra.copySync asks if each folder matches the criteria before moving onto the subdirectory. In this case, it checked `.` first, which returned false, so we didn't copy anything.

Relevant comment from 2017:
https://github.com/jprichardson/node-fs-extra/issues/350#:~:text=You%20may%20have%20the%20same%20puzzle%20as%20I%20had.%20When%20copying%20directory%20and%20use%20the%20filter%20to%20include/exclude%20files%20in%20subdirectory%2C%20it%20actually%20filters%20from%20the%20root%20first.%20If%20the%20root%20folder%20does%20not%20match%20the%20filter%20function%2C%20it%20did%20not%20go%20to%20the%20subdirectory%20at%20all.