### PR TITLE
only run provenance step if environment is not ghes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,7 @@ runs:
     - name: Generate Provenance Attestation
       uses: github-early-access/generate-build-provenance@main
       id: build-provenance
+      if: contains(github.server_url, 'github.com') || contains(github.server_url, 'ghe.com')
       with:
         subject-name: ${{github.repository}}_${{github.ref}}
         subject-digest: ${{steps.publish.outputs.package-manifest-sha}}


### PR DESCRIPTION
Add a check to the `generate-build-provenance` step to stop it running if the environment is GHES. In GHES, the `server_url` is the hostname of the appliance, so the check won't succeed and the step will be skipped.