### PR TITLE
fix ghes condition

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Generate Provenance Attestation
       uses: github-early-access/generate-build-provenance@main
       id: build-provenance
-      if: contains(github.server_url, 'github.com') || contains(github.server_url, 'ghe.com')
+      if: endsWith(github.server_url, 'github.com') || endsWith(github.server_url, 'ghe.com')
       with:
         subject-name: ${{github.repository}}_${{github.ref}}
         subject-digest: ${{steps.publish.outputs.package-manifest-sha}}


### PR DESCRIPTION
# fix ghes condition

Update condition to make sure provenance action doesn't run in GHES to use `endsWith` instead of `contains`.