### PR TITLE
fix lint

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -36,7 +36,7 @@ jobs:
                 | jq '.workflow_runs[] | select(.name=="Publish Actions Package" and (.display_title | contains("${{ github.sha }}"))) | .status, .conclusion')
 
             # split the RESULT into an array
-            RESULT=("$RESULT")
+            mapfile -t RESULT <<< "$RESULT"
             STATUS=$(echo "${RESULT[0]}" | sed -e 's/^"//' -e 's/"$//')
             CONCLUSION=$(echo "${RESULT[1]}" | sed -e 's/^"//' -e 's/"$//')
             if [ -z "$STATUS" ]; then


### PR DESCRIPTION
Fixing lint error:
```
.github/workflows/ci-e2e.yml:27:9: shellcheck reported issue in this script: SC2086:info:14:21: Double quote to prevent globbing and word splitting [shellcheck]
   |
27 |         run: |
   |         ^~~~
```