### PR TITLE
elongated e2e test timeout to 90s

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           START_TIME="$SECONDS"
           TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-          while (( SECONDS - START_TIME < 60 )); do
+          while (( SECONDS - START_TIME < 90 )); do
             echo "Polling for workflow created after $TIMESTAMP"
             RESULT=$(curl -s -L -H "Accept: application/vnd.github+json" \
                 -H "Authorization: Bearer ${{ secrets.PAT }}" \


### PR DESCRIPTION
The `macos-latest` runner completed the test successfully after like 61s