### PR TITLE
add subdirectories in archives

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -99504,7 +99504,7 @@ async function createArchives(distPath, archiveTargetPath) {
             resolve(fileMetadata(zipPath));
         });
         archive.pipe(output);
-        archive.directory(distPath, false);
+        archive.directory(distPath, 'action');
         archive.finalize();
     });
     const createTarPromise = new Promise((resolve, reject) => {
@@ -99512,7 +99512,8 @@ async function createArchives(distPath, archiveTargetPath) {
             .c({
             file: tarPath,
             C: distPath,
-            gzip: true
+            gzip: true,
+            prefix: 'action'
         }, ['.'])
             // eslint-disable-next-line github/no-then
             .catch(err => {

--- a/src/fs-helper.ts
+++ b/src/fs-helper.ts
@@ -48,7 +48,7 @@ export async function createArchives(
     })
 
     archive.pipe(output)
-    archive.directory(distPath, false)
+    archive.directory(distPath, 'action')
     archive.finalize()
   })
 
@@ -58,7 +58,8 @@ export async function createArchives(
         {
           file: tarPath,
           C: distPath,
-          gzip: true
+          gzip: true,
+          prefix: 'action'
         },
         ['.']
       )


### PR DESCRIPTION
# Add subdirectories in archives

This PR should fix https://github.com/github/package-registry-team/issues/7751 - basically, when the runner is attempting to use the tar file, its throwing an error because its treating the files in the root as if they're directories. This PR adds a new `actions` directory at the root of the tar / zip files that will then include the files inside that, so it will only have 1 directory instead.