### PR TITLE
Update source commit in manifest

### DIFF
--- a/src/oci-container.ts
+++ b/src/oci-container.ts
@@ -46,7 +46,7 @@ export function createActionPackageManifest(
       'com.github.package.version': version,
       'com.github.source.repo.id': repoId,
       'com.github.source.repo.owner.id': ownerId,
-      'com.github.source.commit': sourceCommit
+      'org.opencontainers.image.sourcecommit': sourceCommit
     }
   }
 


### PR DESCRIPTION
This changes the source commit in the manifest to use `org.opencontainers.image.sourcecommit`, which is consistent with other container packages.

Related to https://github.com/github/package-registry-team/issues/7920