### PR TITLE
Send auth token to fetch container registry URL API endpoint

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -104365,8 +104365,14 @@ async function getRepositoryMetadata(githubAPIURL, repository, token) {
     };
 }
 exports.getRepositoryMetadata = getRepositoryMetadata;
-async function getContainerRegistryURL(githubAPIURL) {
-    const response = await fetch(`${githubAPIURL}/packages/container-registry-url`);
+async function getContainerRegistryURL(githubAPIURL, token) {
+    const response = await fetch(`${githubAPIURL}/packages/container-registry-url`, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github.v3+json'
+        }
+    });
     if (!response.ok) {
         throw new Error(`Failed to fetch container registry url due to bad status code: ${response.status}`);
     }
@@ -104464,7 +104470,7 @@ async function resolvePublishActionOptions() {
         throw new Error(`Could not find GITHUB_REPOSITORY_OWNER_ID.`);
     }
     // Required Values fetched from the GitHub API
-    const containerRegistryUrl = await apiClient.getContainerRegistryURL(apiBaseUrl);
+    const containerRegistryUrl = await apiClient.getContainerRegistryURL(apiBaseUrl, token);
     const isEnterprise = !githubServerUrl.includes('https://github.com') &&
         !githubServerUrl.endsWith('.ghe.com');
     const repoMetadata = await apiClient.getRepositoryMetadata(apiBaseUrl, nameWithOwner, token);

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -34,10 +34,18 @@ export async function getRepositoryMetadata(
 }
 
 export async function getContainerRegistryURL(
-  githubAPIURL: string
+  githubAPIURL: string,
+  token: string
 ): Promise<URL> {
   const response = await fetch(
-    `${githubAPIURL}/packages/container-registry-url`
+    `${githubAPIURL}/packages/container-registry-url`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.v3+json'
+      }
+    }
   )
   if (!response.ok) {
     throw new Error(

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,8 +92,10 @@ export async function resolvePublishActionOptions(): Promise<PublishActionOption
   }
 
   // Required Values fetched from the GitHub API
-  const containerRegistryUrl: URL =
-    await apiClient.getContainerRegistryURL(apiBaseUrl)
+  const containerRegistryUrl: URL = await apiClient.getContainerRegistryURL(
+    apiBaseUrl,
+    token
+  )
 
   const isEnterprise =
     !githubServerUrl.includes('https://github.com') &&


### PR DESCRIPTION
In order to figure out where to upload the action package, we call an API endpoint `/packages/container-registry-url`, which returns the configured container registry URL (e.g. ghcr.io when calling api.github.com). This endpoint requires no auth, since this is not protected information. 

However, not all environments (especially enterprise based ones like Enterprise Server or Enterprise Cloud) support auth-less requests from the internet. 

This change includes the auth token which we use to talk to other endpoints in the call to get the container registry url.