### PR TITLE
Update permissions on self-publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,20 @@
-name: 'release'
-on: # rebuild any PRs and main branch changes
+# Package and publish the action when a new release is created
+# Since this is the publishing action itself, we can use the current checkout as the action
+name: 'Publish Immutable Action Version'
+on:
   release:
     types: [created]
 permissions:
   id-token: write
-  contents: write
+  attestations: write
   packages: write
 jobs:
-  package-and-publish: 
+  package-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Checking out!
+      - name: Check out repository
         uses: actions/checkout@v4
-      - name: Publish action package
+      - name: Publish Immutable Action Version
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The correct permissions for generating provenance attestations are:

``` yaml
permissions:
  id-token: write
  attestations: write
```

See https://github.com/actions/attest-build-provenance?tab=readme-ov-file#usage

We additionally require `packages: write` because... well, we're writing a package 😄 

-- 

Since our existing linter version does not know about the `attestations` permission, the base branch of this PR is a dependabot branch which updates that linter (see: https://github.com/actions/publish-immutable-action/pull/94). 

We should only merge this once the above PR is merged, so I'm making this a draft PR until then. 