### PR TITLE
Remove unused CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# Repository CODEOWNERS
-
-* @actions/actions-runtime
-* @ncalteen


### PR DESCRIPTION
Use https://github.com/actions/publish-immutable-action/blob/main/CODEOWNERS instead of this file