### PR TITLE
Update @actions/attest dependency and send Attestations API header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/attest": "^1.3.1",
+        "@actions/attest": "^1.4.0",
         "@actions/core": "^1.10.1",
         "@actions/exec": "^1.1.1",
         "@actions/github": "^6.0.0",
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@actions/attest": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.3.1.tgz",
-      "integrity": "sha512-4q09+4QvNROKHsjpusyRhtmUz8kHpFg45n5LqJAYrMQh8mU5O5t9shpGU3Z44rtUebgBTH8Ge0lTzLxfUOVvHw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.4.0.tgz",
+      "integrity": "sha512-vyiv8VuONuIqktf4DdLqYL5sKEPPNTBlmjik+DP+7HqTiOgmrBa4Nn1eKh50aHjxa6tz+VSIYPaw0XG3Zc7zJw==",
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     ]
   },
   "dependencies": {
-    "@actions/attest": "^1.3.1",
+    "@actions/attest": "^1.4.0",
     "@actions/core": "^1.10.1",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^6.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,7 +128,9 @@ async function generateAttestation(
     token: options.token,
     sigstore: 'github',
     // Always store the attestation using the GitHub Attestations API
-    skipWrite: false
+    skipWrite: false,
+    // Identify the attestation to our API as an Immutable Action
+    headers: { 'X-GitHub-Publish-Action': subjectName }
   })
 }
 


### PR DESCRIPTION
This header will help identify requests to the Attestations API as coming from an Immutable Action Publish.