### PR TITLE
Remove attestation write permissions from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
     types: [created]
 permissions:
   id-token: write
-  attestations: write
   packages: write
 jobs:
   package-and-publish:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      attestations: write
       id-token: write
       packages: write
     steps:


### PR DESCRIPTION
This isn't needed now that we're storing attestations in GHCR.