### PR TITLE
Default to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,5 +15,3 @@ jobs:
         uses: actions/checkout@v4
       - name: Publish Immutable Action Version
         uses: ./
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ jobs:
     - name: Publish
       id: publish
       uses: actions/publish-immutable-action@0.0.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 <!-- end usage -->
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ branding:
 inputs:
   github-token:
     description: 'The GitHub actions token used to authenticate with GitHub APIs'
+    default: ${{ github.token }}
 
 outputs:
   package-manifest-sha:


### PR DESCRIPTION
This action does not work with PATs or Integration Tokens. Only the `GITHUB_TOKEN` is supported so we can default to it and remove the `github-token` input from our examples.