### PR TITLE
Use Release Published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
-# Package and publish the action when a new release is created
+# Package and publish the action when a new release is published
 # Since this is the publishing action itself, we can use the current checkout as the action
 name: 'Publish Immutable Action Version'
 on:
   release:
-    types: [created]
+    types: [published]
 permissions:
+  contents: read
   id-token: write
   packages: write
 jobs:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ name: "Publish Immutable Action Version"
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
Releases can be created as drafts. For most people it makes sense to only publish the action once the release is published.