### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -1,0 +1,28 @@
+name: Release new action version
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Tag name that the major tag will point to'
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+permissions:
+  contents: write
+
+jobs:
+  update_tag:
+    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    environment:
+      name: releaseNewActionVersion
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update the ${{ env.TAG_NAME }} tag
+      id: update-major-tag
+      uses: actions/publish-action@v0.3.0
+      with:
+        source-tag: ${{ env.TAG_NAME }}
+        slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -2,20 +2,15 @@ name: Release new action version
 on:
   release:
     types: [released]
-  workflow_dispatch:
-    inputs:
-      TAG_NAME:
-        description: 'Tag name that the major tag will point to'
-        required: true
 
 env:
-  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+  TAG_NAME: ${{ github.event.release.tag_name }}
 permissions:
   contents: write
 
 jobs:
   update_tag:
-    name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
+    name: Update the major tag to include the ${{ github.event.release.tag_name }} changes
     environment:
       name: releaseNewActionVersion
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adding a new workflow similar to what we have in other first party actions to update tags whenever a new release is made. This is for non-immutable versions. Long term this will be removed. 

For example, when we create a `v0.0.4` release in the UI, then this will kick of a workflow that will update the `v0` tag to point to `v0.0.4` (or create `v0` if it doesn't exist yet). With the next release it does the same thing. If `v0.0.5` is published then `v0` will be updated to point to that.

This leverages this action that we are using: https://github.com/actions/publish-action

You can find examples of this exact thing in other first party actions:
- https://github.com/actions/upload-artifact/blob/main/.github/workflows/release-new-action-version.yml
- https://github.com/actions/cache/blob/main/.github/workflows/release-new-action-version.yml